### PR TITLE
feat: add getRandomHex function to generate random hex colors

### DIFF
--- a/src/constants/hexColor.ts
+++ b/src/constants/hexColor.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimum numeric value representable by a 6-digit hexadecimal color.
+ */
+export const MIN_HEX_COLOR = 0x000000;
+
+/**
+ * Maximum numeric value representable by a 6-digit hexadecimal color.
+ */
+export const MAX_HEX_COLOR = 0xffffff;
+
+/**
+ * Prefix used to indicate a valid CSS hexadecimal color string.
+ */
+export const HEX_STRING_PREFIX = '#';
+
+/**
+ * Number of hexadecimal characters in a full 6-digit hex color (excluding the prefix).
+ */
+export const HEX_STRING_LENGTH = 6;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './hexColor';

--- a/src/core/generators/getRandomHex.ts
+++ b/src/core/generators/getRandomHex.ts
@@ -1,0 +1,22 @@
+import {
+  HEX_STRING_LENGTH,
+  HEX_STRING_PREFIX,
+  MAX_HEX_COLOR,
+  MIN_HEX_COLOR,
+} from '../../constants';
+import { getRandomIntInRange } from '../../helpers';
+
+/**
+ * Generates a random color in hexadecimal format (e.g., "#a1b2c3").
+ *
+ * @returns {string} A hexadecimal color string that starts with "#" followed by six hex digits.
+ *
+ * @example
+ * getRandomHex();
+ * // Returns "#3e92f4"
+ */
+export const getRandomHex = (): string => {
+  const randomNumber = getRandomIntInRange(MIN_HEX_COLOR, MAX_HEX_COLOR);
+  const hexString = randomNumber.toString(16).padStart(HEX_STRING_LENGTH, '0');
+  return `${HEX_STRING_PREFIX}${hexString}`;
+};

--- a/src/helpers/getRandomIntInRange.ts
+++ b/src/helpers/getRandomIntInRange.ts
@@ -1,0 +1,3 @@
+export const getRandomIntInRange = (min: number, max: number): number => {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export { getRandomIntInRange } from './getRandomIntInRange';

--- a/test/blah.test.ts
+++ b/test/blah.test.ts
@@ -1,7 +1,0 @@
-import { sum } from '../src';
-
-describe('blah', () => {
-  it('works', () => {
-    expect(sum(1, 1)).toEqual(2);
-  });
-});

--- a/test/core/generators/getRandomHex.test.ts
+++ b/test/core/generators/getRandomHex.test.ts
@@ -1,0 +1,18 @@
+import { getRandomHex } from '../../../src/core/generators/getRandomHex';
+
+describe('getRandomHex', () => {
+  it('should return a valid hexadecimal color string', () => {
+    const result = getRandomHex();
+    // Validar tipo
+    expect(typeof result).toBe('string');
+    // Validar formato HEX con expresión regular
+    expect(result).toMatch(/^#[0-9a-fA-F]{6}$/);
+  });
+
+  it('should start with "#" and be exactly 7 characters long', () => {
+    const result = getRandomHex();
+
+    expect(result.startsWith('#')).toBe(true);
+    expect(result.length).toBe(7);
+  });
+});


### PR DESCRIPTION
## Issue relacionada

[COL-1](https://marloncb.atlassian.net/browse/COL-1)

## Descripción

Se agregó una función que genera un color hexadecimal aleatorio.

## Cambios realizados

- Implementación de la función `getRandomHex`
- Creación de una función de utilidad para generar números aleatorios dentro de un rango
- Agregado el test correspondiente para validar que el valor devuelto sea un color HEX válido
- Incorporación de constantes específicas para colores HEX

## 🧪 ¿Cómo probarlo?

1. Ejecutar los tests con `yarn test`
2. Verificar que `getRandomHex()` retorne siempre un string que cumpla con el formato `#XXXXXX`
3. Validar que nunca se generen valores inválidos fuera del rango hexadecimal estándar

## 📸 Capturas o evidencias (opcional)

_No aplica para esta funcionalidad._

[COL-1]: https://marloncb.atlassian.net/browse/COL-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ