### PR TITLE
feat: add getRandomRgb funtion to generate random rgb colors

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './hexColor';
+export * from './rgbColor';

--- a/src/constants/rgbColor.ts
+++ b/src/constants/rgbColor.ts
@@ -1,0 +1,6 @@
+// Min and max values for RGB channels
+export const RGB_MIN_VALUE = 0;
+export const RGB_MAX_VALUE = 255;
+
+// Template string for RGB CSS format
+export const RGB_STRING_PREFIX = 'rgb';

--- a/src/core/generators/getRandomRgb.ts
+++ b/src/core/generators/getRandomRgb.ts
@@ -1,0 +1,29 @@
+import { RGB_MAX_VALUE, RGB_MIN_VALUE, RGB_STRING_PREFIX } from '../../constants';
+import { getRandomIntInRange } from '../../helpers';
+
+/**
+ * Generates a random color in RGB format.
+ *
+ * @returns {{ r: number, g: number, b: number, toCssString: () => string }}
+ *
+ * @example
+ * getRandomRgb();
+ * // Returns: { r: 123, g: 45, b: 200, toStringCss: () => "rgb(123, 45, 200)" }
+ */
+export const getRandomRgb = (): {
+  r: number;
+  g: number;
+  b: number;
+  toCssString: () => string;
+} => {
+  const r = getRandomIntInRange(RGB_MIN_VALUE, RGB_MAX_VALUE);
+  const g = getRandomIntInRange(RGB_MIN_VALUE, RGB_MAX_VALUE);
+  const b = getRandomIntInRange(RGB_MIN_VALUE, RGB_MAX_VALUE);
+
+  return {
+    r,
+    g,
+    b,
+    toCssString: () => `${RGB_STRING_PREFIX}(${r}, ${g}, ${b})`,
+  };
+};

--- a/src/core/generators/index.ts
+++ b/src/core/generators/index.ts
@@ -1,0 +1,2 @@
+export * from './getRandomRgb';
+export * from './getRandomHex';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,1 @@
+export * from './generators';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,1 @@
-export const sum = (a: number, b: number) => {
-  if ('development' === process.env.NODE_ENV) {
-    console.log('boop');
-  }
-  return a + b;
-};
+export * from './core';

--- a/test/core/generators/getRandomHex.test.ts
+++ b/test/core/generators/getRandomHex.test.ts
@@ -1,4 +1,4 @@
-import { getRandomHex } from '../../../src/core/generators/getRandomHex';
+import { getRandomHex } from '../../../src/core';
 
 describe('getRandomHex', () => {
   it('should return a valid hexadecimal color string', () => {

--- a/test/core/generators/getRandomRgb.test.ts
+++ b/test/core/generators/getRandomRgb.test.ts
@@ -1,0 +1,41 @@
+import { RGB_MAX_VALUE, RGB_MIN_VALUE } from '../../../src/constants';
+import { getRandomRgb } from '../../../src/core';
+
+describe('getRandomRgb', () => {
+  // Verifica que r, g y b sean números dentro del rango válido
+  it('should return an object with r, g, b values in the valid RGB range', () => {
+    const { r, g, b } = getRandomRgb();
+
+    expect(typeof r).toBe('number');
+    expect(typeof g).toBe('number');
+    expect(typeof b).toBe('number');
+
+    expect(r).toBeGreaterThanOrEqual(RGB_MIN_VALUE);
+    expect(r).toBeLessThanOrEqual(RGB_MAX_VALUE);
+    expect(g).toBeGreaterThanOrEqual(RGB_MIN_VALUE);
+    expect(g).toBeLessThanOrEqual(RGB_MAX_VALUE);
+    expect(b).toBeGreaterThanOrEqual(RGB_MIN_VALUE);
+    expect(b).toBeLessThanOrEqual(RGB_MAX_VALUE);
+  });
+
+  // Verifica que toCssString retorne un string CSS válido
+  it('should return a valid CSS rgb string', () => {
+    const color = getRandomRgb();
+    const cssString = color.toCssString();
+
+    expect(cssString).toMatch(/^rgb\(\d{1,3}, \d{1,3}, \d{1,3}\)$/);
+
+    const [r, g, b] = cssString
+      .replace('rgb(', '')
+      .replace(')', '')
+      .split(', ')
+      .map(Number);
+
+    expect(r).toBeGreaterThanOrEqual(RGB_MIN_VALUE);
+    expect(r).toBeLessThanOrEqual(RGB_MAX_VALUE);
+    expect(g).toBeGreaterThanOrEqual(RGB_MIN_VALUE);
+    expect(g).toBeLessThanOrEqual(RGB_MAX_VALUE);
+    expect(b).toBeGreaterThanOrEqual(RGB_MIN_VALUE);
+    expect(b).toBeLessThanOrEqual(RGB_MAX_VALUE);
+  });
+});


### PR DESCRIPTION
## Issue relacionada

[COL-2](https://marloncb.atlassian.net/browse/COL-2)

## Descripción

Se agregó una función que genera un color RGB aleatorio.

## Cambios realizados

- Implementación de la función `getRandomRgb`
- Creación de una función de utilidad para generar números aleatorios dentro de un rango
- Agregado el test correspondiente para validar que el valor devuelto sea un color RGB válido
- Incorporación de constantes específicas para colores RGB

## 🧪 ¿Cómo probarlo?

1. Ejecutar los tests con `yarn test`
2. Verificar que `getRandomRgb()` retorne siempre un objeto con propiedades `r`, `g`, `b` y el método `toCssString()`
3. Validar que `r`, `g` y `b` estén dentro del rango válido de 0 a 255

## 📸 Capturas o evidencias (opcional)

_No aplica para esta funcionalidad._

[COL-2]: https://marloncb.atlassian.net/browse/COL-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ