### PR TITLE
docs: Add Git conventions for branch naming and commit messages

### DIFF
--- a/docs/en/git-guidelines.md
+++ b/docs/en/git-guidelines.md
@@ -1,0 +1,121 @@
+# 🧾 Git Guidelines – Colorum
+
+This document defines the conventions for Git branch names and commit messages used in the **Colorum** project to ensure clarity, consistency, and traceability across all development work.
+
+---
+
+## 📂 Branch Naming Convention
+
+### Format
+
+```
+<type>/<ticket-id>-<kebab-case-description>
+```
+
+- `<type>`: Category of the change (see list below).
+- `<ticket-id>`: **Required for internal team members.** ID of the Jira ticket (e.g., `COL-12`).
+- `<kebab-case-description>`: Short, lowercase description in **English** using hyphens.
+
+### Allowed Types
+
+| Type       | Description                                                                 |
+|------------|-----------------------------------------------------------------------------|
+| `feature`  | Adding a new functionality to the library.                                 |
+| `bugfix`   | Fixing bugs or broken logic.                                                |
+| `refactor` | Improving internal code structure without changing behavior.               |
+| `test`     | Adding or updating test cases.                                              |
+| `docs`     | Updating or improving documentation.                                        |
+| `tooling`  | Configuration, scripts or tools not directly related to the library logic. |
+| `chore`    | Minor changes with no effect on the library logic.                         |
+| `ci`       | Changes related to CI/CD pipelines or deployment scripts.                  |
+
+### Examples
+
+```
+feature/COL-12-add-get-random-rgb
+bugfix/COL-21-fix-hex-validation
+refactor/COL-15-improve-to-css-string
+test/COL-19-add-tests-for-is-valid-rgb
+docs/COL-05-update-readme-examples
+tooling/COL-08-setup-eslint-and-prettier
+chore/COL-31-rename-entry-file
+ci/COL-44-add-test-workflow
+```
+
+🔖 **Ticket reference is required only for internal contributors.**
+
+All team members must link their branches and commits to a Jira ticket (e.g., `COL-12`).
+
+External contributors **can omit** the ticket ID if they are submitting small improvements, documentation updates, or contributions not tied to a planned task.
+
+⚠️ **Important:** Branch descriptions must always be in **English**, regardless of the documentation language or code comments.
+
+---
+
+## ✍️ Commit Message Convention
+
+### Format
+
+```
+<type>: <short description in infinitive form>
+```
+
+- The **type** must match one of the categories used in branch names.
+- The **description** must be written in **English**, in the **infinitive form** (e.g., Add, Fix, Refactor).
+- Do **not** end the subject line with a period.
+- Limit the subject line to **72 characters max**.
+- Leave a blank line before the body (optional).
+- The body can provide context, motivation, or related issues.
+
+### Allowed Types
+
+- `feature`
+- `bugfix`
+- `refactor`
+- `test`
+- `docs`
+- `tooling`
+- `chore`
+- `ci`
+
+### Examples
+
+```
+feature: Add getRandomRgb function
+bugfix: Fix invalid HEX validation
+refactor: Simplify toCssString logic
+test: Add tests for hexToRgb
+docs: Update README with hexToHsl usage
+tooling: Configure function generator script
+chore: Rename main entry file
+ci: Add GitHub Actions workflow for tests
+```
+
+### Example with body
+
+```
+feature: Add getRandomRgb function
+
+This function returns a random RGB color and includes a toCssString() method.
+Related to COL-12.
+```
+
+### Bad Examples
+
+```
+Feature: Add new function         ❌ (capitalized type)
+bugfix: fixed hex validation      ❌ (past tense)
+feature: Agregar nueva función    ❌ (not in English)
+feature: Add color generator.     ❌ (trailing period)
+```
+
+---
+
+## ✅ Additional Rules
+
+- All internal work must be linked to a Jira ticket.
+- Branches must always be created from `main`.
+- Direct commits to `main` are not allowed.
+- Pull requests must be small, focused, and reviewed.
+- Run tests before pushing any changes.
+- `Rebase` is preferred over `merge` to keep the commit history clean (optional).

--- a/docs/es/convenciones-de-git.md
+++ b/docs/es/convenciones-de-git.md
@@ -1,0 +1,119 @@
+# 🧾 Convenciones de Git – Colorum
+
+Este documento define las convenciones para los nombres de ramas y los mensajes de commits usados en el proyecto **Colorum** para asegurar claridad, consistencia y trazabilidad en todo el trabajo de desarrollo.
+
+---
+
+## 📂 Convención de nombres de ramas
+
+### Formato
+
+```
+<tipo>/<id-de-tarea>-<descripcion-en-kebab-case>
+```
+
+- `<tipo>`: Categoría del cambio (ver lista abajo).
+- `<id-de-tarea>`: **Obligatorio para el equipo interno.** Corresponde al ID del ticket en Jira (por ejemplo: `COL-12`).
+- `<descripcion-en-kebab-case>`: Descripción corta, en **inglés**, en minúsculas y con guiones.
+
+### Tipos permitidos
+
+| Tipo       | Descripción                                                                 |
+|------------|-----------------------------------------------------------------------------|
+| `feature`  | Nueva funcionalidad para la librería.                                       |
+| `bugfix`   | Corrección de errores o lógica rota.                                        |
+| `refactor` | Mejora del código sin alterar su comportamiento.                           |
+| `test`     | Agregado o actualización de pruebas.                                        |
+| `docs`     | Cambios en la documentación.                                                |
+| `tooling`  | Scripts o configuraciones que no afectan directamente la lógica del core.  |
+| `chore`    | Cambios menores que no afectan la lógica de la librería.                   |
+| `ci`       | Cambios relacionados con CI/CD o despliegue.                               |
+
+### Ejemplos
+
+```
+feature/COL-12-add-get-random-rgb
+bugfix/COL-21-fix-hex-validation
+refactor/COL-15-improve-to-css-string
+test/COL-19-add-tests-for-is-valid-rgb
+docs/COL-05-update-readme-examples
+tooling/COL-08-setup-eslint-and-prettier
+chore/COL-31-rename-entry-file
+ci/COL-44-add-test-workflow
+```
+
+🔖 **El uso del ID de Jira es obligatorio solo para el equipo interno.**
+
+Los colaboradores externos **pueden omitirlo** si están contribuyendo con mejoras pequeñas, documentación u otros aportes que no están relacionados a tareas planificadas.
+
+⚠️ **Importante:** Las descripciones de las ramas deben estar siempre en **inglés**, independientemente del idioma de la documentación o comentarios del código.
+
+---
+
+## ✍️ Convención para mensajes de commit
+
+### Formato
+
+```
+<tipo>: <descripción corta en infinitivo>
+```
+
+- El **tipo** debe coincidir con uno de los usados en nombres de ramas.
+- La **descripción** debe estar escrita en **inglés**, en infinitivo (por ejemplo: Add, Fix, Refactor).
+- No terminar la línea con punto.
+- Máximo 72 caracteres para la línea principal.
+- Línea en blanco antes del cuerpo (opcional).
+- El cuerpo puede dar más contexto si es necesario.
+
+### Tipos permitidos
+
+- `feature`
+- `bugfix`
+- `refactor`
+- `test`
+- `docs`
+- `tooling`
+- `chore`
+- `ci`
+
+### Ejemplos
+
+```
+feature: Add getRandomRgb function
+bugfix: Fix invalid HEX validation
+refactor: Simplify toCssString logic
+test: Add tests for hexToRgb
+docs: Update README with hexToHsl usage
+tooling: Configure function generator script
+chore: Rename main entry file
+ci: Add GitHub Actions workflow for tests
+```
+
+### Ejemplo con cuerpo
+
+```
+feature: Add getRandomRgb function
+
+This function returns a random RGB color and includes a toCssString() method.
+Related to COL-12.
+```
+
+### Ejemplos incorrectos
+
+```
+Feature: Add new function         ❌ (tipo en mayúsculas)
+bugfix: fixed hex validation      ❌ (pasado)
+feature: Agregar nueva función    ❌ (no está en inglés)
+feature: Add color generator.     ❌ (punto al final)
+```
+
+---
+
+## ✅ Reglas adicionales
+
+- Todo el trabajo del equipo interno debe estar vinculado a un ticket en Jira.
+- Las ramas deben crearse siempre desde `main`.
+- No se permiten commits directos a `main`.
+- Los pull requests deben ser pequeños, enfocados y pasar revisión.
+- Ejecutar pruebas antes de hacer push.
+- Se prefiere `rebase` sobre `merge` para mantener el historial limpio (opcional).


### PR DESCRIPTION
## Issue relacionada

[COL-8](https://marloncb.atlassian.net/browse/COL-8)

## Descripción

Se agregaron las convenciones de Git para el proyecto Colorum, estableciendo estándares claros para el nombramiento de ramas y mensajes de commit. Esto asegura consistencia, claridad y trazabilidad en todo el trabajo de desarrollo del equipo.

## Cambios realizados

- Documentación en español: Actualizada `docs/es/convenciones-de-git.md` con convenciones completas
- Documentación en inglés: Actualizada `docs/en/git-guidelines.md` para mantener consistencia
- Formato de ramas: Establecido formato `<tipo>/<id-tarea>-<descripcion-en-ingles>`
- Tipos de ramas: Definidos 8 tipos permitidos (feature, bugfix, refactor, test, docs, tooling, chore, ci)
- Mensajes de commit: Establecido formato `<tipo>: <descripcion-en-ingles>`
- Ejemplos prácticos: Agregados ejemplos correctos e incorrectos para ambos casos
- Reglas adicionales: Incluidas reglas sobre tickets de Jira, pull requests y flujo de trabajo
- Aclaración de idioma: Especificado que las descripciones deben estar siempre en inglés

## ¿Cómo probarlo?

- Revisar documentación: Verificar que ambos archivos (docs/es/convenciones-de-git.md y docs/en/git-guidelines.md) contengan las mismas convenciones
- Validar ejemplos: Comprobar que los ejemplos de ramas y commits estén en inglés
- Verificar consistencia: Confirmar que las reglas sean claras y aplicables para todo el equipo

## Capturas o evidencias (opcional)

<!-- 
Si aplica, adjunta capturas de pantalla, logs o ejemplos de uso.
Si no aplica, deja la línea de abajo.
-->

_No aplica para esta funcionalidad._ 

[COL-8]: https://marloncb.atlassian.net/browse/COL-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ